### PR TITLE
Do not use baseurls in repository data

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -66,7 +66,7 @@ runs:
           bash -c '
             set -e;
             git clone --branch "${{ inputs.to_branch }}" -- "git@github.com:${{ inputs.to_repository }}.git" upstream;
-            mergerepo_c --verbose --simple-md-filenames --all --no-database --repo="upstream/${{ inputs.to_path }}/releases" --repo="${DFG_01_TMPDIR}/component-repo" --outputdir "${DFG_01_TMPDIR}/merged-repo";
+            mergerepo_c --verbose --omit-baseurl --simple-md-filenames --all --no-database --repo="upstream/${{ inputs.to_path }}/releases" --repo="${DFG_01_TMPDIR}/component-repo" --outputdir "${DFG_01_TMPDIR}/merged-repo";
             rm --recursive --force "upstream/${{ inputs.to_path }}/releases/repodata/";
             mv --verbose "${DFG_01_TMPDIR}/merged-repo/repodata/" "upstream/${{ inputs.to_path }}/releases/repodata";
             echo -e "[${{ inputs.repo_name }}]\nname=${{ inputs.repo_name }}\nbaseurl=${REPO_BASEURL}/releases\ngpgcheck=1\ngpgkey=${REPO_BASEURL}/releases/${{ inputs.repo_name }}-gpg-key.pub\nenabled=1" > "upstream/${{ inputs.to_path }}/releases/${{ inputs.repo_name }}.repo";


### PR DESCRIPTION
## Description
Do not use baseurls in repository data. It is unnecessary, simpler this way

<!-- Please include a summary of changes made in your pull request. -->

<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

- [x] I have tested and verified the functionality
- [x] I have updated README with required information
- [x] I have checked my code contains all required inputs with clear descriptions that has either 'required' OR 'default' with sane value.
- [x] I have checked my code does not contain FIXME or TODO comments
- [x] I have checked my code does not contain any DEBUG commands
- [x] I have checked my code uses only approved third party Actions
- [x] I have checked my code downloads content from only trusted sources
