### PR TITLE
Make repository manager compatible

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,6 +55,8 @@ Examples uses a secret called `DEPLOY_KEY` that contains the key. **DO NOT** har
     max_attempts: 1
     repo_baseurl: https://custom.repo.example.com/example-repo
     repo_name: custom-repo-example
+    location_prefix: 'packages/'
+    repo_baseurl_append_path: true
 ----
 
 == Documentation
@@ -99,19 +101,27 @@ These are optional arguments to be used in `with:` block.
 
 |`to_path`
 |The path where repository files are commited to. No trailing slash required.
-|`central`
+|`central/releases`
 
 |`max_attempts`
 |How times should committing should be attempted.
 |`5`
 
 |`repo_baseurl`
-|The baseurl used in the `.repo` file. Note that it is evaluated to the default value if left empty, and that it can't contain variables if explicitly set. The value of `to_path` is appended to it.
+|The baseurl used in the `.repo` file. Note that it is evaluated to the default value if left empty, and that it can't contain variables if explicitly set. No trailing slash required.
 |`https://raw.githubusercontent.com/${{ inputs.to_repository }}/refs/heads/${{ inputs.to_branch }}/${{ inputs.to_path }}`
+
+|`repo_baseurl_append_path`
+|Append `to_path` to `repo_baseurl`. Only effective when set to `true` and `repo_baseurl` is set to non-default value.
+|`false`
 
 |`repo_name`
 |Sets the repository name.
 |`teragrep-central-releases`
+
+|`location_prefix`
+|Expert setting. Sets the location prefix. Note that it is evaluated to the default value if left empty, and that it can't contain variables if explicitly set. Mostly useful only when using a repository manager that requires relative paths and an url rewriting proxy which redirects requests to the correct location.
+|`https://github.com/${{ inputs.from_repository }}/releases/download/`
 |===
 
 == Contributing

--- a/README.adoc
+++ b/README.adoc
@@ -121,7 +121,7 @@ These are optional arguments to be used in `with:` block.
 
 |`location_prefix`
 |Expert setting. Sets the location prefix. Note that it is evaluated to the default value if left empty, and that it can't contain variables if explicitly set. Mostly useful only when using a repository manager that requires relative paths and an url rewriting proxy which redirects requests to the correct location.
-|`https://github.com/${{ inputs.from_repository }}/releases/download/`
+|`https://github.com/${{ inputs.from_repository }}/releases/download/${{ inputs.from_version }}/`
 |===
 
 == Contributing

--- a/README.adoc
+++ b/README.adoc
@@ -56,7 +56,6 @@ Examples uses a secret called `DEPLOY_KEY` that contains the key. **DO NOT** har
     repo_baseurl: https://custom.repo.example.com/example-repo
     repo_name: custom-repo-example
     location_prefix: 'packages/'
-    repo_baseurl_append_path: true
 ----
 
 == Documentation
@@ -110,10 +109,6 @@ These are optional arguments to be used in `with:` block.
 |`repo_baseurl`
 |The baseurl used in the `.repo` file. Note that it is evaluated to the default value if left empty, and that it can't contain variables if explicitly set. No trailing slash required.
 |`https://raw.githubusercontent.com/${{ inputs.to_repository }}/refs/heads/${{ inputs.to_branch }}/${{ inputs.to_path }}`
-
-|`repo_baseurl_append_path`
-|Append `to_path` to `repo_baseurl`. Only effective when set to `true` and `repo_baseurl` is set to non-default value.
-|`false`
 
 |`repo_name`
 |Sets the repository name.

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ inputs:
     default: 'gh-pages'
     type: string
   to_path:
-    default: 'central'
+    default: 'central/releases'
     type: string
   max_attempts:
     default: 5
@@ -31,8 +31,13 @@ inputs:
     type: string
   repo_baseurl:
     type: string
+  repo_baseurl_append_path:
+    default: false
+    type: string
   repo_name:
     default: 'teragrep-central-releases'
+    type: string
+  location_prefix:
     type: string
 runs:
   using: composite
@@ -43,15 +48,28 @@ runs:
           export REPO_BASEURL="https://raw.githubusercontent.com/${{ inputs.to_repository }}/refs/heads/${{ inputs.to_branch }}/${{ inputs.to_path }}";
           echo "Custom baseurl was not set, using '${REPO_BASEURL}'";
         else
-          export REPO_BASEURL="${{ inputs.repo_baseurl }}/${{ inputs.to_path }}";
-          echo "Detected baseurl, set to '${REPO_BASEURL}'";
+          export REPO_BASEURL="${{ inputs.repo_baseurl }}";
+          if [ "${{ inputs.repo_baseurl_append_path }}" == "true" ]; then
+            echo "Appending '${{ inputs.to_path }}' to baseurl";
+            export REPO_BASEURL="${REPO_BASEURL}/${{ inputs.to_path }}";
+          fi;
+          echo "Detected custom baseurl, set to '${REPO_BASEURL}'";
         fi;
+
+        if [ "${{ inputs.location_prefix }}" == "" ]; then
+          export LOCATION_PREFIX="https://github.com/${{ inputs.from_repository }}/releases/download/${{ inputs.from_version }}/";
+          echo "Location prefix was not set, using default '${LOCATION_PREFIX}'";
+        else
+          export LOCATION_PREFIX="${{ inputs.location_prefix }}";
+          echo "Detected location prefix, set to '${LOCATION_PREFIX}'";
+        fi;
+
         export DFG_01_TMPDIR="$(mktemp --directory --tmpdir=${{ runner.temp }})";
-        mkdir --parents "${DFG_01_TMPDIR}/rpm/${{ inputs.from_version }}" "${DFG_01_TMPDIR}/component-repo" "${DFG_01_TMPDIR}/merged-repo";
-        for file in ${{ inputs.files }}; do ln --verbose "${{ github.workspace }}/${file}" "${DFG_01_TMPDIR}/rpm/${{ inputs.from_version }}/$(basename ${file})"; done;
+        mkdir --parents "${DFG_01_TMPDIR}/packages" "${DFG_01_TMPDIR}/component-repo" "${DFG_01_TMPDIR}/merged-repo";
+        for file in ${{ inputs.files }}; do ln --verbose "${{ github.workspace }}/${file}" "${DFG_01_TMPDIR}/packages/$(basename ${file})"; done;
         sudo apt-get update;
         sudo apt-get --yes install createrepo-c;
-        createrepo_c --verbose --no-database --location-prefix="https://github.com/${{ inputs.from_repository }}/releases/download/" --outputdir="${DFG_01_TMPDIR}/component-repo" "${DFG_01_TMPDIR}/rpm";
+        createrepo_c --verbose --no-database --location-prefix="${LOCATION_PREFIX}" --outputdir="${DFG_01_TMPDIR}/component-repo" "${DFG_01_TMPDIR}/packages";
         git config --global user.email "${{ github.actor }}@users.noreply.github.com";
         git config --global user.name "${{ github.actor }}";
         echo "${GH_SSH_KEY}" > "${DFG_01_TMPDIR}/ssh.key";
@@ -66,16 +84,16 @@ runs:
           bash -c '
             set -e;
             git clone --branch "${{ inputs.to_branch }}" -- "git@github.com:${{ inputs.to_repository }}.git" upstream;
-            if [ ! -d "upstream/${{ inputs.to_path }}/releases" ]; then
+            if [ ! -d "upstream/${{ inputs.to_path }}" ]; then
               echo "Upstream repository not found, creating a new one from scratch";
-              mkdir --parents "upstream/${{ inputs.to_path }}/releases";
-              createrepo_c --verbose --no-database --simple-md-filenames --compress-type=gz --general-compress-type=gz --outputdir="upstream/${{ inputs.to_path }}/releases" "upstream/${{ inputs.to_path }}/releases";
+              mkdir --parents "upstream/${{ inputs.to_path }}";
+              createrepo_c --verbose --no-database --simple-md-filenames --compress-type=gz --general-compress-type=gz --outputdir="upstream/${{ inputs.to_path }}" "upstream/${{ inputs.to_path }}";
             fi;
-            mergerepo_c --verbose --omit-baseurl --simple-md-filenames --all --no-database --repo="upstream/${{ inputs.to_path }}/releases" --repo="${DFG_01_TMPDIR}/component-repo" --outputdir "${DFG_01_TMPDIR}/merged-repo";
-            rm --recursive --force "upstream/${{ inputs.to_path }}/releases/repodata/";
-            mv --verbose "${DFG_01_TMPDIR}/merged-repo/repodata/" "upstream/${{ inputs.to_path }}/releases/repodata";
-            echo -e "[${{ inputs.repo_name }}]\nname=${{ inputs.repo_name }}\nbaseurl=${REPO_BASEURL}/releases\ngpgcheck=1\ngpgkey=${REPO_BASEURL}/releases/${{ inputs.repo_name }}-gpg-key.pub\nenabled=1" > "upstream/${{ inputs.to_path }}/releases/${{ inputs.repo_name }}.repo";
-            echo "${{ inputs.gpg_public_key }}" > "upstream/${{ inputs.to_path }}/releases/${{ inputs.repo_name }}-gpg-key.pub";
+            mergerepo_c --verbose --omit-baseurl --simple-md-filenames --all --no-database --repo="upstream/${{ inputs.to_path }}" --repo="${DFG_01_TMPDIR}/component-repo" --outputdir "${DFG_01_TMPDIR}/merged-repo";
+            rm --recursive --force "upstream/${{ inputs.to_path }}/repodata/";
+            mv --verbose "${DFG_01_TMPDIR}/merged-repo/repodata/" "upstream/${{ inputs.to_path }}/repodata";
+            echo -e "[${{ inputs.repo_name }}]\nname=${{ inputs.repo_name }}\nbaseurl=${REPO_BASEURL}\ngpgcheck=1\ngpgkey=${REPO_BASEURL}/${{ inputs.repo_name }}-gpg-key.pub\nenabled=1" > "upstream/${{ inputs.to_path }}/${{ inputs.repo_name }}.repo";
+            echo "${{ inputs.gpg_public_key }}" > "upstream/${{ inputs.to_path }}/${{ inputs.repo_name }}-gpg-key.pub";
             cd "upstream/${{ inputs.to_path }}";
             git add .;
             git commit --message "Adds ${{ inputs.from_repository }} version ${{ inputs.from_version }}";

--- a/action.yaml
+++ b/action.yaml
@@ -30,40 +30,21 @@ inputs:
     required: true
     type: string
   repo_baseurl:
-    type: string
-  repo_baseurl_append_path:
-    default: false
+    default: 'https://raw.githubusercontent.com/${{ inputs.to_repository }}/refs/heads/${{ inputs.to_branch }}/${{ inputs.to_path }}'
     type: string
   repo_name:
     default: 'teragrep-central-releases'
     type: string
   location_prefix:
+    default: 'https://github.com/${{ inputs.from_repository }}/releases/download/${{ inputs.from_version }}/'
     type: string
 runs:
   using: composite
   steps:
     - name: Add component to main repository
       run: |
-        if [ "${{ inputs.repo_baseurl }}" == "" ]; then
-          export REPO_BASEURL="https://raw.githubusercontent.com/${{ inputs.to_repository }}/refs/heads/${{ inputs.to_branch }}/${{ inputs.to_path }}";
-          echo "Custom baseurl was not set, using '${REPO_BASEURL}'";
-        else
-          export REPO_BASEURL="${{ inputs.repo_baseurl }}";
-          if [ "${{ inputs.repo_baseurl_append_path }}" == "true" ]; then
-            echo "Appending '${{ inputs.to_path }}' to baseurl";
-            export REPO_BASEURL="${REPO_BASEURL}/${{ inputs.to_path }}";
-          fi;
-          echo "Detected custom baseurl, set to '${REPO_BASEURL}'";
-        fi;
-
-        if [ "${{ inputs.location_prefix }}" == "" ]; then
-          export LOCATION_PREFIX="https://github.com/${{ inputs.from_repository }}/releases/download/${{ inputs.from_version }}/";
-          echo "Location prefix was not set, using default '${LOCATION_PREFIX}'";
-        else
-          export LOCATION_PREFIX="${{ inputs.location_prefix }}";
-          echo "Detected location prefix, set to '${LOCATION_PREFIX}'";
-        fi;
-
+        echo "Using '${REPO_BASEURL}' as baseurl";
+        echo "Using '${LOCATION_PREFIX}' as location prefix";
         export DFG_01_TMPDIR="$(mktemp --directory --tmpdir=${{ runner.temp }})";
         mkdir --parents "${DFG_01_TMPDIR}/packages" "${DFG_01_TMPDIR}/component-repo" "${DFG_01_TMPDIR}/merged-repo";
         for file in ${{ inputs.files }}; do ln --verbose "${{ github.workspace }}/${file}" "${DFG_01_TMPDIR}/packages/$(basename ${file})"; done;
@@ -110,3 +91,5 @@ runs:
       shell: bash
       env:
         GH_SSH_KEY: "${{ inputs.deploy_key }}"
+        REPO_BASEURL: "${{ inputs.repo_baseurl }}"
+        LOCATION_PREFIX: "${{ inputs.location_preix }}"

--- a/action.yaml
+++ b/action.yaml
@@ -30,21 +30,33 @@ inputs:
     required: true
     type: string
   repo_baseurl:
-    default: 'https://raw.githubusercontent.com/${{ inputs.to_repository }}/refs/heads/${{ inputs.to_branch }}/${{ inputs.to_path }}'
     type: string
   repo_name:
     default: 'teragrep-central-releases'
     type: string
   location_prefix:
-    default: 'https://github.com/${{ inputs.from_repository }}/releases/download/${{ inputs.from_version }}/'
     type: string
 runs:
   using: composite
   steps:
     - name: Add component to main repository
       run: |
-        echo "Using '${REPO_BASEURL}' as baseurl";
-        echo "Using '${LOCATION_PREFIX}' as location prefix";
+        if [ "${{ inputs.repo_baseurl }}" == "" ]; then
+          export REPO_BASEURL="https://raw.githubusercontent.com/${{ inputs.to_repository }}/refs/heads/${{ inputs.to_branch }}/${{ inputs.to_path }}";
+          echo "Custom baseurl was not set, using '${REPO_BASEURL}'";
+        else
+          export REPO_BASEURL="${{ inputs.repo_baseurl }}";
+          echo "Detected custom baseurl, set to '${REPO_BASEURL}'";
+        fi;
+
+        if [ "${{ inputs.location_prefix }}" == "" ]; then
+          export LOCATION_PREFIX="https://github.com/${{ inputs.from_repository }}/releases/download/${{ inputs.from_version }}/";
+          echo "Location prefix was not set, using default '${LOCATION_PREFIX}'";
+        else
+          export LOCATION_PREFIX="${{ inputs.location_prefix }}";
+          echo "Detected location prefix, set to '${LOCATION_PREFIX}'";
+        fi;
+
         export DFG_01_TMPDIR="$(mktemp --directory --tmpdir=${{ runner.temp }})";
         mkdir --parents "${DFG_01_TMPDIR}/packages" "${DFG_01_TMPDIR}/component-repo" "${DFG_01_TMPDIR}/merged-repo";
         for file in ${{ inputs.files }}; do ln --verbose "${{ github.workspace }}/${file}" "${DFG_01_TMPDIR}/packages/$(basename ${file})"; done;
@@ -91,5 +103,3 @@ runs:
       shell: bash
       env:
         GH_SSH_KEY: "${{ inputs.deploy_key }}"
-        REPO_BASEURL: "${{ inputs.repo_baseurl }}"
-        LOCATION_PREFIX: "${{ inputs.location_preix }}"


### PR DESCRIPTION
## Description

Removes hardcoded values
Adds setting for overriding location prefix

If baseurl is not set -> Use gh-pages as usual
If baseurl is set -> Everything is set to exactly that value

If location prefix is not set -> Use direct links to github rpm releases
If location prefix is set -> Use that as prefix, requires url rewriting proxy

<!-- Please include a summary of changes made in your pull request. -->

<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

- [x] I have tested and verified the functionality
- [x] I have updated README with required information
- [x] I have checked my code contains all required inputs with clear descriptions that has either 'required' OR 'default' with sane value.
- [x] I have checked my code does not contain FIXME or TODO comments
- [x] I have checked my code does not contain any DEBUG commands
- [x] I have checked my code uses only approved third party Actions
- [x] I have checked my code downloads content from only trusted sources
